### PR TITLE
fix broken partcad package

### DIFF
--- a/partcad.yaml
+++ b/partcad.yaml
@@ -113,15 +113,15 @@ assemblies:
   Arm:
     type: assy
     desc: The robot arm
-  Drag_chain:
-    type: assy
-    desc: The robot's drag chain
-  Electronics_case:
-    type: assy
-    desc: The robot's electronics case
-  Robot:
-    type: assy
-    desc: The robot frame's parts
+  # Drag_chain:
+  #   type: assy
+  #   desc: The robot's drag chain
+  # Electronics_case:
+  #   type: assy
+  #   desc: The robot's electronics case
+  # Robot:
+  #   type: assy
+  #   desc: The robot frame's parts
 
 render:
   svg:


### PR DESCRIPTION
- Removed `Draig_chain.assy`, `Electronic_case.assy` and `Robot.assy`
- Commented out assemblies defined in `partcad.yaml` that are associated with these files